### PR TITLE
Fix an issue with nesting functions that support ShouldProcess

### DIFF
--- a/functions/Add-UserGroup.ps1
+++ b/functions/Add-UserGroup.ps1
@@ -36,8 +36,12 @@ function Add-UserGroup {
         $Context = $null
     )
 
-    if ($PSCmdlet.ShouldProcess($UserId, 'Add Group Membership')) {
-        $result = Update-UserGroup @PSBoundParameters -Status 'ACTIVE' -Verbose:$VerbosePreference -Confirm:$false
+    if ($PSCmdlet.ShouldProcess($UserId, 'Remove Group Membership')) {
+        $PSBoundParameters.Status = 'ACTIVE'
+        $PSBoundParameters.Verbose = $VerbosePreference
+        $PSBoundParameters.Confirm = $false
+
+        $result = Update-UserGroup @PSBoundParameters
         $result
     }
 }

--- a/functions/Remove-UserGroup.ps1
+++ b/functions/Remove-UserGroup.ps1
@@ -37,7 +37,11 @@ function Remove-UserGroup {
     )
 
     if ($PSCmdlet.ShouldProcess($UserId, 'Remove Group Membership')) {
-        $result = Update-UserGroup @PSBoundParameters -Status 'DELETED' -Verbose:$VerbosePreference -Confirm:$false
+        $PSBoundParameters.Status = 'DELETED'
+        $PSBoundParameters.Verbose = $VerbosePreference
+        $PSBoundParameters.Confirm = $false
+
+        $result = Update-UserGroup @PSBoundParameters
         $result
     }
 }


### PR DESCRIPTION
By calling the outer function with a `-Confirm:$false` that then becomes part of the PSBoundParameters. Then when we splat that on the inner function and add our own `-Confirm:$false` PowerShell gets upset because the same parameter is provided twice. I believe this is being fixed in PS 7.2 but that doesn't do a library type module like this much good. 